### PR TITLE
Add CorridorThreshold parameter for Footprint tool.

### DIFF
--- a/Scripts/Applications/Tool_Call_Example.py
+++ b/Scripts/Applications/Tool_Call_Example.py
@@ -52,12 +52,20 @@ def main():
     # FLM_Tools.preTagging(in_line, in_chm, in_canopy_raster, in_cost_raster, in_lidar_year, out_tagged_line)
     # FLM_Tools.centerline(in_line, in_cost_raster, out_center_line)
     # FLM_Tools.lineFootprint(in_line, in_canopy_raster, in_cost_raster, out_footprint)
-    FLM_Tools.lineAttribute("WHOLE-LINE", out_center_line, out_footprint, in_chm, out_attribute_whole)
+    # FLM_Tools.lineAttribute("WHOLE-LINE", out_center_line, out_footprint, in_chm, out_attribute_whole)
     # FLM_Tools.lineAttribute("ARBITRARY", out_center_line, out_footprint, in_chm, out_attribute_arbitrary)
     # FLM_Tools.lineAttribute("IN-FEATURES", out_center_line, out_footprint, in_chm, out_attribute_in_features)
     # FLM_Tools.lineAttribute("LINE-CROSSINGS", out_center_line, out_footprint, in_chm, out_attribute_line_crossings)
     # FLM_Tools.vertexOptimization(in_line, in_cost_raster, out_center_line_optimize)
 
+    import json
+
+    with open(r"D:\FLM_Sensituvity_Test\footprint_below2m.json") as json_file:
+        params = json.load(json_file)
+
+        for i in params:
+            FLM_Tools.lineFootprint(i["in_line"], i["canopy_raster"], i["cost_raster"],
+                                    i["out_footprint"], max_line_width=i["line_width"])
 
 if __name__ == "__main__":
     main()

--- a/Scripts/FLM_LineFootprint.py
+++ b/Scripts/FLM_LineFootprint.py
@@ -232,10 +232,9 @@ def workLinesMemory(segment_info):
     Corridor_Threshold_Field = f.readline().strip()
     Maximum_distance_from_centerline = float(f.readline().strip())
     Expand_And_Shrink_Cell_Range = f.readline().strip()
+    Corridor_Threshold = f.readline().strip()
     f.close()
 
-    # TODO: this is constant, but need to be investigated.
-    Corridor_Threshold = 3
     lineNo = segment_info[1]  # second element is the line No.
     outWorkspaceMem = r"memory"
 
@@ -440,11 +439,13 @@ def main(argv=None):
     Expand_And_Shrink_Cell_Range = args[5].rstrip()
     global ProcessSegments
     ProcessSegments = args[6].rstrip() == "True"
-    global Output_Footprint
+    global Corridor_Threshold
     Output_Footprint = args[7].rstrip()
+    global Output_Footprint
+    Output_Footprint = args[8].rstrip()
     outWorkspace = flmc.SetupWorkspace(workspaceName)
 
-    # write params to text file
+    # write params to text file for use in function workLinesMemory
     f = open(outWorkspace + "\\params.txt", "w")
     f.write(outWorkspace + "\n")
     f.write(Centerline_Feature_Class + "\n")
@@ -453,6 +454,7 @@ def main(argv=None):
     f.write(Corridor_Threshold_Field + "\n")
     f.write(str(Maximum_distance_from_centerline) + "\n")
     f.write(Expand_And_Shrink_Cell_Range + "\n")
+    f.write(str(Corridor_Threshold) + "\n")
     f.close()
 
     # TODO: this code block is not necessary

--- a/Scripts/FLM_LineFootprint.py
+++ b/Scripts/FLM_LineFootprint.py
@@ -230,9 +230,9 @@ def workLinesMemory(segment_info):
     Canopy_Raster = f.readline().strip()
     Cost_Raster = f.readline().strip()
     Corridor_Threshold_Field = f.readline().strip()
+    Corridor_Threshold = float(f.readline().strip())
     Maximum_distance_from_centerline = float(f.readline().strip())
     Expand_And_Shrink_Cell_Range = f.readline().strip()
-    Corridor_Threshold = f.readline().strip()
     f.close()
 
     lineNo = segment_info[1]  # second element is the line No.
@@ -433,14 +433,14 @@ def main(argv=None):
     Cost_Raster = args[2].rstrip()
     global Corridor_Threshold_Field
     Corridor_Threshold_Field = args[3].rstrip()
-    global Maximum_distance_from_centerline
-    Maximum_distance_from_centerline = float(args[4].rstrip()) / 2.0
-    global Expand_And_Shrink_Cell_Range
-    Expand_And_Shrink_Cell_Range = args[5].rstrip()
-    global ProcessSegments
-    ProcessSegments = args[6].rstrip() == "True"
     global Corridor_Threshold
-    Output_Footprint = args[7].rstrip()
+    Corridor_Threshold = args[4].rstrip()
+    global Maximum_distance_from_centerline
+    Maximum_distance_from_centerline = float(args[5].rstrip()) / 2.0
+    global Expand_And_Shrink_Cell_Range
+    Expand_And_Shrink_Cell_Range = args[6].rstrip()
+    global ProcessSegments
+    ProcessSegments = args[7].rstrip() == "True"
     global Output_Footprint
     Output_Footprint = args[8].rstrip()
     outWorkspace = flmc.SetupWorkspace(workspaceName)
@@ -452,9 +452,9 @@ def main(argv=None):
     f.write(Canopy_Raster + "\n")
     f.write(Cost_Raster + "\n")
     f.write(Corridor_Threshold_Field + "\n")
+    f.write(Corridor_Threshold + "\n")
     f.write(str(Maximum_distance_from_centerline) + "\n")
     f.write(Expand_And_Shrink_Cell_Range + "\n")
-    f.write(str(Corridor_Threshold) + "\n")
     f.close()
 
     # TODO: this code block is not necessary

--- a/Scripts/FLM_Tools.py
+++ b/Scripts/FLM_Tools.py
@@ -117,7 +117,8 @@ def centerline(in_line, in_cost_raster, out_center_line,
 def lineFootprint(in_center_line, in_canopy_raster, in_cost_raster,
                    out_footprint,
                    corridor_thresh="CorridorTh", max_line_width=10,
-                   expand_shrink_range=0, process_segments=False):
+                   expand_shrink_range=0, process_segments=False,
+                   corridor_threshold = 3):
     """
     Generate line footprint
     """
@@ -131,7 +132,8 @@ def lineFootprint(in_center_line, in_canopy_raster, in_cost_raster,
     argv[4] = str(max_line_width)  # maximam line width
     argv[5] = str(expand_shrink_range)  # expand and shrink cell range
     argv[6] = str(process_segments)  # process segments
-    argv[7] = out_footprint  # Output line foot print
+    argv[7] = str(corridor_threshold)
+    argv[8] = out_footprint  # Output line foot print
 
     if not os.path.exists(in_center_line):
         print("Input line file {} not exists, ignore.".format(in_center_line))

--- a/Scripts/FLM_Tools.py
+++ b/Scripts/FLM_Tools.py
@@ -121,10 +121,11 @@ def lineFootprint(in_center_line, in_canopy_raster, in_cost_raster,
                    corridor_threshold=3):
     """
     Generate line footprint
+
     """
 
     print("Processing canopy line footprint: ", out_footprint)
-    argv = [None] * 8
+    argv = [None] * 9
     argv[0] = in_center_line  # center line
     argv[1] = in_canopy_raster  # canopy raster
     argv[2] = in_cost_raster  # Cost raster

--- a/Scripts/FLM_Tools.py
+++ b/Scripts/FLM_Tools.py
@@ -118,7 +118,7 @@ def lineFootprint(in_center_line, in_canopy_raster, in_cost_raster,
                    out_footprint,
                    corridor_thresh="CorridorTh", max_line_width=10,
                    expand_shrink_range=0, process_segments=False,
-                   corridor_threshold = 3):
+                   corridor_threshold=3):
     """
     Generate line footprint
     """

--- a/Scripts/flm_tools.json
+++ b/Scripts/flm_tools.json
@@ -143,7 +143,7 @@
                             "description": "Height threshold in meters above which CHM pixels are considered canopy.",
                             "type": "number",
                             "typelab": "number",
-                            "default": "1",
+                            "default": "0.5",
                             "output": false
                         },
                         {
@@ -151,7 +151,7 @@
                             "description": "Radius of canopy influence in the cost raster. This factor smooths the canopy in the cost raster which helps to prevent gaps in sparsely vegetated areas (e.g. wetlands) to be incorrectly identified as footprint. A large search radius (>=5m) may cause excessive smoothing of the cost raster which can lead to least cost paths ignoring forest-line nuances in sparsely vegetated forests. A small radius (<=1m) may cause the least cost path to cut corners through small gaps in sparse vegetation as well as avoid small obstacles that should not affect overall line shape.",
                             "type": "number",
                             "typelab": "number",
-                            "default": "3",
+                            "default": "1.5",
                             "output": false
                         },
                         {
@@ -159,7 +159,7 @@
                             "description": "Maximum euclidean distance from canopy. This is a second smoothing factor which helps to position the forest line shape in the center of the line footprint. An excessively small (<=1m) or large (>20m) value may cause the center line to be positioned close to one of the edges of the footprint.",
                             "type": "number",
                             "typelab": "number",
-                            "default": "10",
+                            "default": "1.5",
                             "output": false
                         },
                         {
@@ -167,7 +167,7 @@
                             "description": "Ratio of importance between canopy search radius and euclidean distance. A value close to zero (0) prioritizes search radius whereas a value close to one (1) prioritizes euclidean distance. A small value (<=0.1) may cause the forest lines to miss nuances in sparsely vegetated terrain whereas a big value (>=0.5) may overemphasize turns in complex trails. This factor influences final footprint size in a minor way.",
                             "type": "number",
                             "typelab": "number",
-                            "default": "0.3",
+                            "default": "0.0",
                             "output": false
                         },
                         {
@@ -175,7 +175,7 @@
                             "description": "Affects the cost of vegetated areas in an exponential fashion. A low (<=1) exponent may lead to lines cutting through corners, whereas a large (>=3) exponent may lead to least cost paths completely avoiding narrow lines.",
                             "type": "number",
                             "typelab": "number",
-                            "default": "1.5",
+                            "default": "1",
                             "output": false
                         },
                         {
@@ -226,7 +226,7 @@
                             "description": "Maximum processing distance from input lines. A large search radius may increase processing times whereas a small radius may cause undesired clipping.",
                             "type": "number",
                             "typelab": "number",
-                            "default": "35",
+                            "default": "15",
                             "output": false
                         },
                         {

--- a/Scripts/flm_tools.json
+++ b/Scripts/flm_tools.json
@@ -289,6 +289,14 @@
                             "output": false
                         },
                         {
+                            "parameter": "Corridor Threshold",
+                            "description": "The least cost corridor thresholds (LCCT).",
+                            "type": "number",
+                            "typelab": "number",
+                            "default": "3",
+                            "output": false
+                        },
+                        {
                             "parameter": "Maximum Line Width",
                             "description": "Maximum processing width for input lines. A large value may increase processing times whereas a small value may cause undesired clipping.",
                             "type": "number",


### PR DESCRIPTION
CorridorTh was transfered by centerline shapefile and always set to 3. We are going to make it a parameter for Footprint tool and remove CorridorTh in centerline shapefile.